### PR TITLE
Chicken 5 Support

### DIFF
--- a/TODO.org
+++ b/TODO.org
@@ -19,15 +19,6 @@
 
   Another implication is that cock must be aware of the module (i.e.
   the module must be documented and included in the cock-invocation).
-* TODO Invoke command-line git instead of libgit2.
-  To extract tags, for instance:
-
-  #+BEGIN_SRC sh
-    git tag -n1
-  #+END_SRC
-
-  =Libgit2= is a horrific dependency: specific versions required,
-  random segfaults, etc.
 * TODO Create a test-creation mechanism.
 * TODO Looks like there might be an extra newline for =@text=.
   See e.g. [[https://wiki.call-cc.org/eggref/4/R?action%3Dedit][R]].
@@ -242,6 +233,16 @@
   Maybe this can be an extension.
 * TODO Multiple authors (maintainer, &c.)
   [[http://tex.stackexchange.com/questions/9594/adding-more-than-one-author-with-different-affiliation][Using footnotes]] and [[http://tex.stackexchange.com/questions/4805/whats-the-correct-use-of-author-when-multiple-authors][using \texttt{\char`\\ and}]].
+* DONE Invoke command-line git instead of libgit2.
+CLOSED: [2019-09-27 Fri 12:14]
+  To extract tags, for instance:
+
+  #+BEGIN_SRC sh
+    git tag -n1
+  #+END_SRC
+
+  =Libgit2= is a horrific dependency: specific versions required,
+  random segfaults, etc.
 * DONE Add monospace to parameters.
   CLOSED: [2014-12-27 Sat 20:38]
 * DONE Module-awareness?

--- a/build-hahn-utils
+++ b/build-hahn-utils
@@ -1,0 +1,10 @@
+#!/bin/sh
+"$CHICKEN_CSC" -X hahn $@
+
+command -v hahn && hahn -o hahn-utils.wiki \
+                        hahn-utils.scm \
+                        hahn-parse-core.scm \
+                        hahn-parse-wiki.scm \
+                        hahn-parse-latex.scm
+
+exit 0

--- a/hahn-parse-core.scm
+++ b/hahn-parse-core.scm
@@ -278,14 +278,18 @@
     ;; We have to check for directory-existence here; libgit2 seems to
     ;; segfault when the directory doesn't exist on repository-open.
     (when (directory-exists? repo)
-      (let* ((repo (repository-open repo))
-             (tags (tags repo)))
+      (let* ((tags (call-with-input-pipe "git tag -n"
+                                         (lambda (p)
+                                           (map string-split
+                                                (read-lines p))))))
         (hash-table-set! metadata
                          'versions
                          (sort
-                          (map (lambda (tag) (cons (tag-name tag)
-                                                   (tag-message tag)))
-                               tags)
+                          (map
+                           (lambda (tag)
+                             (cons (car tag)
+                                   (string-join (cdr tag))))
+                           tags)
                           (lambda (a b) version<=? (car a) (car b))))))
     metadata))
 

--- a/hahn-parse-core.scm
+++ b/hahn-parse-core.scm
@@ -5,10 +5,11 @@
 (define docexprs (make-parameter (make-stack)))
 
 (define-syntax thunk
-  (lambda (expression rename compare)
+  (er-macro-transformer
+   (lambda (expression rename compare)
     (let ((body (cdr expression))
           (%lambda (rename 'lambda)))
-      `(,%lambda () ,@body))))
+      `(,%lambda () ,@body)))))
 
 (define-record-and-printer null-expression)
 (define null-expression (make-null-expression))
@@ -281,10 +282,9 @@
                          'versions
                          (sort
                           (map (lambda (tag) (cons (tag-name tag)
-                                              (tag-message tag)))
+                                                   (tag-message tag)))
                                tags)
-                          version<=?
-                          car))))
+                          (lambda (a b) version<=? (car a) (car b))))))
     metadata))
 
 (define parse-metafile
@@ -323,6 +323,6 @@ returns the value of executing {{thunk}}."
     (thunk "The thunk to execute")
     (@to "object"))
   (let ((original-directory (current-directory)))
-    (dynamic-wind (lambda () (current-directory directory))
+    (dynamic-wind (lambda () (change-directory directory))
         thunk
-        (lambda () (current-directory original-directory)))))
+        (lambda () (change-directory original-directory)))))

--- a/hahn-parse-wiki.scm
+++ b/hahn-parse-wiki.scm
@@ -528,6 +528,7 @@ whole document (useful for debugging)"))
               (dependencies
                (or (hash-table-ref/default data 'depends #f)
                    (hash-table-ref/default data 'needs #f)
+                   (hash-table-ref/default data 'dependencies #f)
                    '()))
               (license
                (hash-table-ref/default data 'license #f))

--- a/hahn-utils.egg
+++ b/hahn-utils.egg
@@ -14,7 +14,6 @@ wiki.")
                hahn
                define-record-and-printer
                fmt
-               git
                matchable
                miscmacros
                shell

--- a/hahn-utils.egg
+++ b/hahn-utils.egg
@@ -1,5 +1,7 @@
 ((synopsis "Translates in-source documentation from [[hahn]] into
 wiki.")
+ (author "Peter Danenberg")
+ ;; repo: https://github.com/klutometis/hahn-utils
  (category doc-tools)
  (license "BSD")
  (dependencies alist-lib

--- a/hahn-utils.egg
+++ b/hahn-utils.egg
@@ -1,0 +1,27 @@
+((synopsis "Translates in-source documentation from [[hahn]] into
+wiki.")
+ (category doc-tools)
+ (license "BSD")
+ (dependencies alist-lib
+               srfi-1
+               srfi-13
+               srfi-14
+               srfi-69
+               regex
+               args
+               hahn
+               define-record-and-printer
+               fmt
+               git
+               matchable
+               miscmacros
+               shell
+               stack)
+ (test-dependencies hahn test)
+ (component-options (csc-options "-X" "hahn"))
+ (components
+  (extension hahn-utils)
+  (program hahn
+           (source "bin/hahn.scm")
+           (component-dependencies hahn-utils)
+           (custom-build build-hahn-utils))))

--- a/hahn-utils.meta
+++ b/hahn-utils.meta
@@ -11,7 +11,6 @@ wiki.")
           debug
           define-record-and-printer
           fmt
-          git
           matchable
           miscmacros
           shell

--- a/hahn-utils.scm
+++ b/hahn-utils.scm
@@ -40,14 +40,16 @@ drivers then write docexprs as e.g. wiki, LaTeX.")
    wiki-write-docexprs
    with-working-directory
    version<=?) 
-  (import chicken
-          data-structures
-          extras
-          ports
-          scheme
-          srfi-1
-          stack)
-  (use alist-lib
+  (import scheme)
+  (cond-expand
+    (chicken-4
+     (import chicken
+             data-structures
+             extras
+             ports
+             srfi-1
+             stack)
+     (use alist-lib
        debug
        define-record-and-printer
        fmt
@@ -62,7 +64,29 @@ drivers then write docexprs as e.g. wiki, LaTeX.")
        srfi-69
        srfi-95
        stack
-       utils)
+       utils))
+    (chicken-5
+     (import chicken.base
+             chicken.port
+             chicken.sort
+             chicken.irregex
+             chicken.pretty-print
+             chicken.process-context
+             chicken.file
+             chicken.string
+             chicken.format
+             chicken.read-syntax
+             srfi-1
+             alist-lib
+             define-record-and-printer
+             fmt
+             git
+             srfi-13
+             srfi-14
+             srfi-69
+             matchable
+             regex
+             stack)))
 
   (import-for-syntax matchable)
 

--- a/hahn-utils.scm
+++ b/hahn-utils.scm
@@ -76,6 +76,7 @@ drivers then write docexprs as e.g. wiki, LaTeX.")
              chicken.string
              chicken.format
              chicken.read-syntax
+             chicken.io
              srfi-1
              alist-lib
              define-record-and-printer

--- a/hahn-utils.scm
+++ b/hahn-utils.scm
@@ -53,7 +53,6 @@ drivers then write docexprs as e.g. wiki, LaTeX.")
        debug
        define-record-and-printer
        fmt
-       git
        irregex
        lolevel
        matchable
@@ -77,11 +76,11 @@ drivers then write docexprs as e.g. wiki, LaTeX.")
              chicken.format
              chicken.read-syntax
              chicken.io
+             chicken.process
              srfi-1
              alist-lib
              define-record-and-printer
              fmt
-             git
              srfi-13
              srfi-14
              srfi-69

--- a/tests/run.scm
+++ b/tests/run.scm
@@ -1,8 +1,12 @@
-(use hahn
-     hahn-utils
-     files
-     ports
-     test)
+(cond-expand
+  (chicken-4
+   (use hahn
+      hahn-utils
+      files
+      ports
+      test))
+  (chicken-5
+   (import hahn hahn-utils chicken.file chicken.port test)))
 
 (define (with-output-to-temporary-file thunk)
   @("Outputs to a temporary file and returns that file."


### PR DESCRIPTION
So I think this is 'pretty alright, could be better' as far as preliminary C5 support goes. A couple things:

- Every maybe 2 out of 7 runs or something, I'm getting a finalizers related segfault warning. gdb tells me originates in libgit2.so, and indeed, commenting out the `repository-open` code gets rid of it (but, of course, also does away with the tags feature). It must be something about the `git` egg, but I've no idea how to reproduce it (besides running hahn a few times in a row), or what's triggering it. Luckily it seems to not be affecting documentation generation at the moment.

- For C5, we parse the .egg file instead of .meta and allow for `;; keyword: value` style metadata, since `.egg` files are strict about what keywords can be included.

- There's no real built-in way to run a script after all extensions are built in C5, since custom build scripts run once per extension. We sort of have to resort to running hahn in a custom build script for one component of the egg (that depends on everything else, so that hahn is run last). This could be a proper extension that really does depend on the rest (as is the case here), or an extension with fake deps added so it's compiled last, or just something like dummy component (e.g. a data file, maybe the .egg file itself, with every other component as a dep).