### PR TITLE
Add foreign procedure support + tests

### DIFF
--- a/hahn-parse-core.scm
+++ b/hahn-parse-core.scm
@@ -114,6 +114,15 @@
       ((or ('define (procedure . formals) . body)
            ('define procedure ('lambda formals . body)))
        ((parse-procedure) doc expr data procedure formals))
+      (('define procedure ((or 'foreign-lambda
+                               'foreign-safe-lambda)
+                           ret name . formals))
+       ((parse-procedure) doc expr data procedure formals ret))
+      (('define procedure ((or 'foreign-lambda*
+                               'foreign-safe-lambda*
+                               'foreign-primitive)
+                           ret formals . body))
+       ((parse-procedure) doc expr data procedure (map cadr formals) ret))
       (('define procedure ('case-lambda (formals . body) ...))
        ((parse-case-lambda) doc expr data procedure formals))
       (('define parameter ('make-parameter init . converter))
@@ -164,7 +173,8 @@
         (string->symbol "@example-no-eval")
         (string->symbol "@internal")
         (string->symbol "@no-source")
-        (string->symbol "@to")))
+        (string->symbol "@to")
+        (string->symbol "@args")))
 
 (define (special-parameter? parameter)
   (memq parameter special-parameters))
@@ -183,10 +193,17 @@
       (values normal-parameters special-parameters))))
 
 ;;; Generalize this.
-(define (procedure-to special-parameters)
+(define (procedure-to special-parameters #!optional foreign-ret)
   (alist-ref/default special-parameters
                      (string->symbol "@to")
-                     '("unspecified")))
+                     (or (and foreign-ret
+                              (list (symbol->string foreign-ret)))
+                         '("unspecified"))))
+
+(define (procedure-args special-parameters formals)
+  (alist-ref/default special-parameters
+                     (string->symbol "@args")
+                     formals))
 
 (define example-description car)
 

--- a/hahn-parse-latex.scm
+++ b/hahn-parse-latex.scm
@@ -252,10 +252,11 @@
          ;; Already texified above.
          (string-join parameters "\\\\\n")))))
 
-(define (tex-parse-procedure doc expr data name formals)
+(define (tex-parse-procedure doc expr data name formals #!optional foreign-ret)
   (receive (normal-parameters special-parameters)
     (doc-normal-and-special-parameters doc)
-    (let ((to (procedure-to special-parameters)))
+    (let ((to (procedure-to special-parameters foreign-ret))
+          (formals (procedure-args special-parameters formals)))
       (let ((procedure
              (make-tex-procedure tex-procedure name formals to))
             (parameters (make-tex-parameters

--- a/hahn-parse-wiki.scm
+++ b/hahn-parse-wiki.scm
@@ -335,10 +335,11 @@ to {{require-extension}} all modules seen so far.")
           parameters)))
     (string-join parameters "\n")))
 
-(define (wiki-parse-procedure doc expr data name formals)
+(define (wiki-parse-procedure doc expr data name formals #!optional foreign-ret)
   (receive (normal-parameters special-parameters)
     (doc-normal-and-special-parameters doc)
-    (let ((to (procedure-to special-parameters)))
+    (let ((to (procedure-to special-parameters foreign-ret))
+          (formals (procedure-args special-parameters formals)))
       (let ((procedure
              (make-wiki-procedure wiki-procedure name formals to))
             (parameters

--- a/tests/run.scm
+++ b/tests/run.scm
@@ -70,6 +70,48 @@ Using +
      (- x (- y)))))
 
 (test
+ "=== {{ffi-foo*}}
+<procedure>(ffi-foo* hey thing) → int</procedure>
+FFI Description
+
+<enscript highlight=\"scheme\">(define ffi-foo*
+  (foreign-lambda* int ((double hey) (size_t thing)) \"C_return(bar);\"))
+</enscript>
+"
+ (parse-and-write-fragment-as-string
+  `(define ffi-foo*
+     ,at("FFI Description")
+     (foreign-lambda* int ((double hey) (size_t thing))
+       "C_return(bar);"))))
+
+(test
+ "=== {{ffi-foo}}
+<procedure>(ffi-foo double size_t) → int</procedure>
+FFI Description
+
+<enscript highlight=\"scheme\">(define ffi-foo (foreign-lambda int \"fn_name\" double size_t))
+</enscript>
+"
+ (parse-and-write-fragment-as-string
+  `(define ffi-foo
+     ,at("FFI Description")
+     (foreign-lambda int "fn_name" double size_t))))
+
+(test
+ "=== {{change-args}}
+<procedure>(change-args one two) → unspecified</procedure>
+change-args description
+
+<enscript highlight=\"scheme\">(define (change-args a b) (print \"Nothing\"))
+</enscript>
+"
+ (parse-and-write-fragment-as-string
+  `(define (change-args a b)
+     ,at("change-args description"
+         (@args one two))
+     (print "Nothing"))))
+
+(test
  "=== {{module}}
 '''[module]''' {{module}}
 


### PR DESCRIPTION
- Also adds `@args` directive to change the args of a function, useful for
  foreign-lambda and foreign-safe-lambda, where argumnets have
  non-descriptive c-type names